### PR TITLE
specify pyhton bin version

### DIFF
--- a/todo-jira-check.py
+++ b/todo-jira-check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python -s
+#!/usr/bin/env python3 -s
 
 # Searches passed files for TODO comments.
 #


### PR DESCRIPTION
Redhat does not support using the `python` bin name without specifying the version (`python2` or `python3`), thus failing the hook.

since python 2 is EOL anyways, thought it might be sensible to use `python3`

https://developers.redhat.com/blog/2019/05/07/what-no-python-in-red-hat-enterprise-linux-8/